### PR TITLE
feat(user): add create user endpoint with tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "2.0.21"
+    kotlin("plugin.spring") version "2.0.21"
     id("org.springframework.boot") version "3.5.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
@@ -17,9 +18,13 @@ repositories {
 }
 
 dependencies {
-    // Spring Boot
+    // Spring Boot / Web
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // Kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Database
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql:10.13.0")
 
     // Testing
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
     testImplementation("io.kotest:kotest-assertions-core:5.8.0")
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/controller/UserController.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/controller/UserController.kt
@@ -1,0 +1,25 @@
+package com.github.cdraz.todoapi.controller
+
+import com.github.cdraz.todoapi.dto.CreateUserRequest
+import com.github.cdraz.todoapi.dto.UserResponse
+import com.github.cdraz.todoapi.service.UserService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/users")
+class UserController(
+    private val userService: UserService
+) {
+    @PostMapping
+    @ResponseStatus(CREATED)
+    fun createUser(
+        @Valid @RequestBody request: CreateUserRequest
+    ): UserResponse =
+        userService.createUser(request)
+}

--- a/src/main/kotlin/com/github/cdraz/todoapi/dto/CreateUserRequest.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/dto/CreateUserRequest.kt
@@ -1,0 +1,10 @@
+package com.github.cdraz.todoapi.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class CreateUserRequest(
+    @field:Email
+    @field:NotBlank
+    val email: String
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/dto/UserResponse.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/dto/UserResponse.kt
@@ -1,0 +1,9 @@
+package com.github.cdraz.todoapi.dto
+
+import java.time.Instant
+
+data class UserResponse(
+    val id: Long,
+    val email: String,
+    val createdAt: Instant
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/entity/UserEntity.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/entity/UserEntity.kt
@@ -1,0 +1,24 @@
+package com.github.cdraz.todoapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "users")
+class UserEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, unique = true)
+    val email: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/EmailAlreadyExistsException.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/EmailAlreadyExistsException.kt
@@ -1,0 +1,4 @@
+package com.github.cdraz.todoapi.exception
+
+class EmailAlreadyExistsException(email: String) :
+    RuntimeException("User with email '$email' already exists")

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package com.github.cdraz.todoapi.exception
+
+import java.time.Instant
+
+data class ErrorResponse(
+    val status: Int,
+    val error: String,
+    val message: String?,
+    val details: Map<String, String>? = null,
+    val timestamp: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,95 @@
+package com.github.cdraz.todoapi.exception
+
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.http.converter.HttpMessageNotReadableException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    // Handles validation failures on @Valid @RequestBody DTOs (e.g. invalid JSON fields)
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException
+    ): ResponseEntity<ErrorResponse> {
+        val errors = ex.bindingResult.fieldErrors
+            .associate { it.field to (it.defaultMessage ?: "Invalid value") }
+
+        return ResponseEntity.badRequest().body(
+            ErrorResponse(
+                status = HttpStatus.BAD_REQUEST.value(),
+                error = "Validation failed",
+                message = "One or more request fields are invalid",
+                details = errors
+            )
+        )
+    }
+
+    // Handles validation failures on path variables, request params, and service-layer validation
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolation(
+        ex: ConstraintViolationException
+    ): ResponseEntity<ErrorResponse> {
+        val errors = ex.constraintViolations
+            .associate { violation ->
+                violation.propertyPath.toString() to violation.message
+            }
+
+        return ResponseEntity.badRequest().body(
+            ErrorResponse(
+                status = HttpStatus.BAD_REQUEST.value(),
+                error = "Constraint violation",
+                message = "One or more constraints were violated",
+                details = errors
+            )
+        )
+    }
+
+    // Handles attempts to create a user with an email that already exists
+    @ExceptionHandler(EmailAlreadyExistsException::class)
+    fun handleEmailAlreadyExists(
+        ex: EmailAlreadyExistsException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            ErrorResponse(
+                status = HttpStatus.CONFLICT.value(),
+                error = "Email already exists",
+                message = ex.message
+            )
+        )
+    }
+
+    // Handles malformed or unreadable JSON in the request body
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @Suppress("UnusedParameter") // Surpressing unused parameter for detekt
+    fun handleUnreadableMessage(
+        ex: HttpMessageNotReadableException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.badRequest().body(
+            ErrorResponse(
+                status = HttpStatus.BAD_REQUEST.value(),
+                error = "Malformed request",
+                message = "Request body is missing or invalid JSON"
+            )
+        )
+    }
+
+    // Fallback handler for any unhandled exceptions (internal server errors)
+    @ExceptionHandler(Exception::class)
+    @Suppress("UnusedParameter") // Surpressing unused parameter for detekt
+    fun handleGenericException(
+        ex: Exception
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+            ErrorResponse(
+                status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                error = "Internal server error",
+                message = "An unexpected error occurred"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/github/cdraz/todoapi/repository/UserRepository.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/repository/UserRepository.kt
@@ -1,0 +1,9 @@
+package com.github.cdraz.todoapi.repository
+
+import com.github.cdraz.todoapi.entity.UserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<UserEntity, Long> {
+    fun existsByEmail(email: String): Boolean
+    fun findByEmail(email: String): UserEntity?
+}

--- a/src/main/kotlin/com/github/cdraz/todoapi/service/UserService.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/service/UserService.kt
@@ -1,0 +1,33 @@
+package com.github.cdraz.todoapi.service
+
+import com.github.cdraz.todoapi.dto.CreateUserRequest
+import com.github.cdraz.todoapi.dto.UserResponse
+import com.github.cdraz.todoapi.entity.UserEntity
+import com.github.cdraz.todoapi.exception.EmailAlreadyExistsException
+import com.github.cdraz.todoapi.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(
+    private val userRepository: UserRepository
+) {
+    @Transactional
+    fun createUser(request: CreateUserRequest): UserResponse {
+        if (userRepository.existsByEmail(request.email)) {
+            throw EmailAlreadyExistsException(request.email)
+        }
+
+        val user = UserEntity(
+            email = request.email
+        )
+
+        val savedUser = userRepository.save(user)
+
+        return UserResponse(
+            id = savedUser.id,
+            email = savedUser.email,
+            createdAt = savedUser.createdAt
+        )
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,5 +23,5 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.SQL: OFF
+    org.hibernate.orm.jdbc.bind: OFF

--- a/src/test/kotlin/com/github/cdraz/todoapi/controller/UserControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/controller/UserControllerWebMvcTest.kt
@@ -1,0 +1,71 @@
+package com.github.cdraz.todoapi.controller
+
+import com.github.cdraz.todoapi.dto.UserResponse
+import com.github.cdraz.todoapi.service.UserService
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.Instant
+
+@WebMvcTest(UserController::class)
+class UserControllerWebMvcTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var userService: UserService
+
+    @Test
+    fun `POST users returns 201 when request is valid`() {
+        val requestEmail = "test@example.com"
+
+        val response = UserResponse(
+            id = 1L,
+            email = requestEmail,
+            createdAt = Instant.now()
+        )
+
+        every { userService.createUser(match { it.email == requestEmail }) } returns response
+
+        mockMvc.post("/users") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"email":"$requestEmail"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id") { value(1) }
+            jsonPath("$.email") { value(requestEmail) }
+        }
+
+        verify(exactly = 1) { userService.createUser(match { it.email == requestEmail }) }
+    }
+
+    @Test
+    fun `POST users returns 400 when email is blank`() {
+        mockMvc.post("/users") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"email":""}"""
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { userService.createUser(any()) }
+    }
+
+    @Test
+    fun `POST users returns 400 when request body is missing`() {
+        mockMvc.post("/users") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { userService.createUser(any()) }
+    }
+}

--- a/src/test/kotlin/com/github/cdraz/todoapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/service/UserServiceTest.kt
@@ -1,0 +1,62 @@
+package com.github.cdraz.todoapi.service
+
+import com.github.cdraz.todoapi.dto.CreateUserRequest
+import com.github.cdraz.todoapi.entity.UserEntity
+import com.github.cdraz.todoapi.exception.EmailAlreadyExistsException
+import com.github.cdraz.todoapi.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+
+class UserServiceTest : DescribeSpec({
+
+    val userRepository = mockk<UserRepository>(relaxed = false)
+    val userService = UserService(userRepository)
+
+    afterTest {
+        clearMocks(userRepository)
+    }
+
+    describe("createUser") {
+
+        it("creates a new user when email does not already exist") {
+            val request = CreateUserRequest(email = "test@example.com")
+
+            val savedEntity = UserEntity(
+                id = 1L,
+                email = request.email,
+                createdAt = Instant.now()
+            )
+
+            every { userRepository.existsByEmail(eq("test@example.com")) } returns false
+            every { userRepository.save(any()) } returns savedEntity
+
+            val result = userService.createUser(request)
+
+            result.id shouldBe 1L
+            result.email shouldBe "test@example.com"
+            result.createdAt shouldBe savedEntity.createdAt
+
+            verify(exactly = 1) { userRepository.existsByEmail("test@example.com") }
+            verify(exactly = 1) { userRepository.save(any()) }
+        }
+
+        it("throws EmailAlreadyExistsException when email already exists") {
+            val request = CreateUserRequest(email = "duplicate@example.com")
+
+            every { userRepository.existsByEmail(eq("duplicate@example.com")) } returns true
+
+            shouldThrow<EmailAlreadyExistsException> {
+                userService.createUser(request)
+            }
+
+            verify(exactly = 1) { userRepository.existsByEmail("duplicate@example.com") }
+            verify(exactly = 0) { userRepository.save(any()) }
+        }
+    }
+})


### PR DESCRIPTION
### Summary
Introducing User creation to the API including validation, error handling, and test coverage

### Changes
- Added request/response DTOs for creating users
- Implemented `UserRepository` for user persistence
- Added `UserService` with create-user logic and duplicate email checks
- Exposed `POST /users` endpoint via `UserController`
- Introduced a global exception handler with domain-specific exceptions
- Added unit tests for the user service and controller