### PR TITLE
feat(todo): add PATCH endpoints for todo.title and todo.completed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 
     // Kotlin
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Database
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -333,7 +333,7 @@ naming:
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    functionPattern: '[a-z][a-zA-Z0-9]*'
+    functionPattern: '[a-z][a-zA-Z0-9_]*'
     excludeClassPattern: '$^'
   FunctionParameterNaming:
     active: true

--- a/queries/Queries.sql
+++ b/queries/Queries.sql
@@ -1,0 +1,62 @@
+-- --------------------------------------------------
+-- USERS
+-- --------------------------------------------------
+
+-- List users (newest first)
+SELECT id, email, created_at
+FROM public.users
+ORDER BY created_at DESC;
+
+-- Find a user by id
+SELECT id, email, created_at
+FROM public.users
+WHERE id = :user_id;
+
+-- Find a user by email (exact)
+SELECT id, email, created_at
+FROM public.users
+WHERE email = :email;
+
+-- Count users
+SELECT COUNT(*) AS user_count
+FROM public.users;
+
+-- -- Delete a user (will cascade to todos)
+-- -- DELETE FROM public.users WHERE id = :user_id;
+
+-- --------------------------------------------------
+-- TODOS
+-- --------------------------------------------------
+
+-- List all todos (newest first)
+SELECT id, title, completed, created_at, user_id
+FROM public.todos
+ORDER BY created_at DESC;
+
+-- Find a todo by id
+SELECT id, title, completed, created_at, user_id
+FROM public.todos
+WHERE id = :todo_id;
+
+-- Fetch todos for a given userId (newest first)
+SELECT id, title, completed, created_at, user_id
+FROM public.todos
+WHERE user_id = :user_id
+ORDER BY created_at DESC;
+
+-- Fetch only incomplete todos for a userId
+SELECT id, title, completed, created_at, user_id
+FROM public.todos
+WHERE user_id = :user_id
+  AND completed = false
+ORDER BY created_at DESC;
+
+-- Fetch only completed todos for a userId
+SELECT id, title, completed, created_at, user_id
+FROM public.todos
+WHERE user_id = :user_id
+  AND completed = true
+ORDER BY created_at DESC;
+
+-- -- Delete all todos for a user
+-- -- DELETE FROM public.todos WHERE user_id = :user_id;

--- a/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
@@ -7,6 +7,7 @@ import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.service.TodoService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.OK
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -29,7 +30,7 @@ class TodoController(
         todoService.createTodo(userId, request)
 
     @PatchMapping("/{todoId}/title")
-    @ResponseStatus(CREATED)
+    @ResponseStatus(OK)
     fun updateTitle(
         @PathVariable userId: Long,
         @PathVariable todoId: Long,
@@ -38,7 +39,7 @@ class TodoController(
         todoService.updateTodoTitle(userId, todoId, request)
 
     @PatchMapping("/{todoId}/completed")
-    @ResponseStatus(CREATED)
+    @ResponseStatus(OK)
     fun updateCompletion(
         @PathVariable userId: Long,
         @PathVariable todoId: Long,

--- a/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
@@ -2,9 +2,12 @@ package com.github.cdraz.todoapi.controller
 
 import com.github.cdraz.todoapi.dto.CreateTodoRequest
 import com.github.cdraz.todoapi.dto.TodoResponse
+import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
+import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.service.TodoService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,4 +27,22 @@ class TodoController(
         @Valid @RequestBody request: CreateTodoRequest
     ): TodoResponse =
         todoService.createTodo(userId, request)
+
+    @PatchMapping("/{todoId}/title")
+    @ResponseStatus(CREATED)
+    fun updateTitle(
+        @PathVariable userId: Long,
+        @PathVariable todoId: Long,
+        @Valid @RequestBody request: UpdateTodoTitleRequest
+    ): TodoResponse =
+        todoService.updateTodoTitle(userId, todoId, request)
+
+    @PatchMapping("/{todoId}/completed")
+    @ResponseStatus(CREATED)
+    fun updateCompletion(
+        @PathVariable userId: Long,
+        @PathVariable todoId: Long,
+        @Valid @RequestBody request: UpdateTodoCompletionRequest
+    ): TodoResponse =
+        todoService.updateTodoCompletion(userId, todoId, request)
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/dto/UpdateTodoCompletionRequest.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/dto/UpdateTodoCompletionRequest.kt
@@ -1,0 +1,5 @@
+package com.github.cdraz.todoapi.dto
+
+data class UpdateTodoCompletionRequest(
+    val completed: Boolean
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/dto/UpdateTodoTitleRequest.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/dto/UpdateTodoTitleRequest.kt
@@ -1,0 +1,8 @@
+package com.github.cdraz.todoapi.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateTodoTitleRequest(
+    @field:NotBlank
+    val title: String
+)

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
@@ -106,4 +106,15 @@ class GlobalExceptionHandler {
             )
         )
     }
+
+    @ExceptionHandler(TodoNotFoundForUserException::class)
+    fun handleTodoNotFound(ex: TodoNotFoundForUserException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            ErrorResponse(
+                status = HttpStatus.NOT_FOUND.value(),
+                error = "Todo not found",
+                message = ex.message
+            )
+        )
+    }
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/TodoNotFoundForUserException.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/TodoNotFoundForUserException.kt
@@ -1,0 +1,4 @@
+package com.github.cdraz.todoapi.exception
+
+class TodoNotFoundForUserException(todoId: Long, userId: Long):
+    RuntimeException("Todo $todoId not found for user $userId")

--- a/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
@@ -1,11 +1,8 @@
 package com.github.cdraz.todoapi.repository
 
 import com.github.cdraz.todoapi.entity.TodoEntity
-import com.github.cdraz.todoapi.entity.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TodoRepository : JpaRepository<TodoEntity, Long> {
-    fun findAllByUser(user: UserEntity): List<TodoEntity>
-    fun existsByIdAndUser(id: Long, user: UserEntity): Boolean
-    fun findAllByUserId(userId: Long): List<TodoEntity>
+    fun findByIdAndUserId(id: Long, userId: Long): TodoEntity?
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
@@ -4,5 +4,6 @@ import com.github.cdraz.todoapi.entity.TodoEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TodoRepository : JpaRepository<TodoEntity, Long> {
-    fun findByIdAndUserId(id: Long, userId: Long): TodoEntity?
+    // underscore to demonstrate relationship traversal; we want todo.user.id not todo.userId
+    fun findByIdAndUser_Id(id: Long, userId: Long): TodoEntity?
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
@@ -2,7 +2,10 @@ package com.github.cdraz.todoapi.service
 
 import com.github.cdraz.todoapi.dto.CreateTodoRequest
 import com.github.cdraz.todoapi.dto.TodoResponse
+import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
+import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.entity.TodoEntity
+import com.github.cdraz.todoapi.exception.TodoNotFoundForUserException
 import com.github.cdraz.todoapi.exception.UserNotFoundException
 import com.github.cdraz.todoapi.repository.TodoRepository
 import com.github.cdraz.todoapi.repository.UserRepository
@@ -27,12 +30,40 @@ class TodoService(
 
         val savedTodo = todoRepository.save(todo)
 
-        return TodoResponse(
-            id = savedTodo.id,
-            title = savedTodo.title,
-            completed = savedTodo.completed,
-            createdAt = savedTodo.createdAt,
-            userId = savedTodo.user.id
-        )
+        return savedTodo.toResponse()
     }
+
+    @Transactional
+    fun updateTodoTitle(userId: Long, todoId: Long, request: UpdateTodoTitleRequest): TodoResponse {
+        val todo = todoRepository.findByIdAndUserId(todoId, userId)
+            ?: throw TodoNotFoundForUserException(todoId, userId)
+
+        if (todo.title != request.title) {
+            todo.title = request.title
+        }
+
+        return todo.toResponse()
+    }
+
+
+    @Transactional
+    fun updateTodoCompletion(userId: Long, todoId: Long, request: UpdateTodoCompletionRequest): TodoResponse {
+        val todo = todoRepository.findByIdAndUserId(todoId, userId)
+            ?: throw TodoNotFoundForUserException(todoId, userId)
+
+        if (todo.completed != request.completed) {
+            todo.completed = request.completed
+        }
+
+        return todo.toResponse()
+    }
+
+    private fun TodoEntity.toResponse(): TodoResponse =
+        TodoResponse(
+            id = this.id,
+            title = this.title,
+            completed = this.completed,
+            createdAt = this.createdAt,
+            userId = this.user.id
+        )
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
@@ -35,7 +35,7 @@ class TodoService(
 
     @Transactional
     fun updateTodoTitle(userId: Long, todoId: Long, request: UpdateTodoTitleRequest): TodoResponse {
-        val todo = todoRepository.findByIdAndUserId(todoId, userId)
+        val todo = todoRepository.findByIdAndUser_Id(todoId, userId)
             ?: throw TodoNotFoundForUserException(todoId, userId)
 
         if (todo.title != request.title) {
@@ -48,7 +48,7 @@ class TodoService(
 
     @Transactional
     fun updateTodoCompletion(userId: Long, todoId: Long, request: UpdateTodoCompletionRequest): TodoResponse {
-        val todo = todoRepository.findByIdAndUserId(todoId, userId)
+        val todo = todoRepository.findByIdAndUser_Id(todoId, userId)
             ?: throw TodoNotFoundForUserException(todoId, userId)
 
         if (todo.completed != request.completed) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
     schemas: public
     locations: classpath:db/migration
 
+  jackson:
+    deserialization:
+      fail-on-missing-creator-properties: true
+      fail-on-null-for-primitives: true
+
 logging:
   level:
     org.hibernate.SQL: OFF

--- a/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
@@ -85,4 +85,18 @@ class TodoControllerWebMvcTest {
 
         verify(exactly = 0) { todoService.createTodo(any(), any()) }
     }
+
+    @Test
+    fun `PATCH users userId todos todoId title returns 400 when request body is missing`() {
+        val userId = 1L
+        val todoId = 1
+
+        mockMvc.post("/users/$userId/todos/$todoId/title") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { todoService.createTodo(any(), any()) }
+    }
 }

--- a/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
@@ -2,6 +2,8 @@ package com.github.cdraz.todoapi.controller
 
 import com.github.cdraz.todoapi.dto.CreateTodoRequest
 import com.github.cdraz.todoapi.dto.TodoResponse
+import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
+import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.service.TodoService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 import java.time.Instant
 
@@ -87,16 +90,145 @@ class TodoControllerWebMvcTest {
     }
 
     @Test
+    fun `PATCH users userId todos todoId title returns 200 when request is valid`() {
+        val userId = 1L
+        val todoId = 2L
+        val newTitle = "Updated title"
+
+        val response = TodoResponse(
+            id = todoId,
+            title = newTitle,
+            completed = false,
+            createdAt = Instant.now(),
+            userId = userId
+        )
+
+        every {
+            todoService.updateTodoTitle(
+                userId,
+                todoId,
+                match { it.title == newTitle }
+            )
+        } returns response
+
+        mockMvc.patch("/users/$userId/todos/$todoId/title") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"title":"$newTitle"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.id") { value(2) }
+            jsonPath("$.title") { value(newTitle) }
+            jsonPath("$.completed") { value(false) }
+            jsonPath("$.userId") { value(1) }
+        }
+
+        verify(exactly = 1) {
+            todoService.updateTodoTitle(
+                userId,
+                todoId,
+                match<UpdateTodoTitleRequest> { it.title == newTitle }
+            )
+        }
+    }
+
+    @Test
+    fun `PATCH users userId todos todoId title returns 400 when title is blank`() {
+        val userId = 1L
+        val todoId = 2L
+
+        mockMvc.patch("/users/$userId/todos/$todoId/title") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"title":""}"""
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { todoService.updateTodoTitle(any(), any(), any()) }
+    }
+
+    @Test
     fun `PATCH users userId todos todoId title returns 400 when request body is missing`() {
         val userId = 1L
-        val todoId = 1
+        val todoId = 2L
 
-        mockMvc.post("/users/$userId/todos/$todoId/title") {
+        mockMvc.patch("/users/$userId/todos/$todoId/title") {
             contentType = MediaType.APPLICATION_JSON
         }.andExpect {
             status { isBadRequest() }
         }
 
-        verify(exactly = 0) { todoService.createTodo(any(), any()) }
+        verify(exactly = 0) { todoService.updateTodoTitle(any(), any(), any()) }
+    }
+
+
+    @Test
+    fun `PATCH users userId todos todoId completed returns 200 when request is valid`() {
+        val userId = 1L
+        val todoId = 2L
+        val completed = true
+
+        val response = TodoResponse(
+            id = todoId,
+            title = "Apply for jobs",
+            completed = completed,
+            createdAt = Instant.now(),
+            userId = userId
+        )
+
+        every {
+            todoService.updateTodoCompletion(
+                userId,
+                todoId,
+                match { it.completed == completed }
+            )
+        } returns response
+
+        mockMvc.patch("/users/$userId/todos/$todoId/completed") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"completed":$completed}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.id") { value(2) }
+            jsonPath("$.completed") { value(true) }
+            jsonPath("$.userId") { value(1) }
+        }
+
+        verify(exactly = 1) {
+            todoService.updateTodoCompletion(
+                userId,
+                todoId,
+                match<UpdateTodoCompletionRequest> { it.completed == completed }
+            )
+        }
+    }
+
+    @Test
+    fun `PATCH users userId todos todoId completed returns 400 when request body is missing`() {
+        val userId = 1L
+        val todoId = 2L
+
+        mockMvc.patch("/users/$userId/todos/$todoId/completed") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { todoService.updateTodoCompletion(any(), any(), any()) }
+    }
+
+    @Test
+    fun `PATCH users userId todos todoId completed returns 400 when completed field is missing`() {
+        val userId = 1L
+        val todoId = 2L
+
+        // JSON exists but missing the required boolean field -> binding error -> 400
+        mockMvc.patch("/users/$userId/todos/$todoId/completed") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{}"""
+        }.andExpect {
+            status { isBadRequest() }
+        }
+
+        verify(exactly = 0) { todoService.updateTodoCompletion(any(), any(), any()) }
     }
 }

--- a/src/test/kotlin/com/github/cdraz/todoapi/service/TodoServiceTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/service/TodoServiceTest.kt
@@ -1,8 +1,11 @@
 package com.github.cdraz.todoapi.service
 
 import com.github.cdraz.todoapi.dto.CreateTodoRequest
+import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
+import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.entity.TodoEntity
 import com.github.cdraz.todoapi.entity.UserEntity
+import com.github.cdraz.todoapi.exception.TodoNotFoundForUserException
 import com.github.cdraz.todoapi.exception.UserNotFoundException
 import com.github.cdraz.todoapi.repository.TodoRepository
 import com.github.cdraz.todoapi.repository.UserRepository
@@ -10,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -73,6 +77,201 @@ class TodoServiceTest : DescribeSpec({
 
             verify(exactly = 1) { userRepository.findById(missingUserId) }
             verify(exactly = 0) { todoRepository.save(any()) }
+        }
+    }
+
+    describe("updateTodoTitle") {
+
+        it("updates the title when todo exists for the user") {
+            val userId = 1L
+            val todoId = 10L
+            val oldTitle = "Old title"
+            val newTitle = "New title"
+
+            val user = UserEntity(
+                id = userId,
+                email = "test@example.com",
+                createdAt = Instant.now()
+            )
+
+            val todo = TodoEntity(
+                id = todoId,
+                title = oldTitle,
+                completed = false,
+                createdAt = Instant.now(),
+                user = user
+            )
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns todo
+
+            val result = todoService.updateTodoTitle(
+                userId = userId,
+                todoId = todoId,
+                request = UpdateTodoTitleRequest(title = newTitle)
+            )
+
+            // entity mutated
+            todo.title shouldBe newTitle
+
+            // response reflects updated entity
+            result.id shouldBe todoId
+            result.title shouldBe newTitle
+            result.completed shouldBe false
+            result.createdAt shouldBe todo.createdAt
+            result.userId shouldBe userId
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
+        }
+
+        it("does not change the title when the new title is the same") {
+            val userId = 1L
+            val todoId = 10L
+            val sameTitle = "Same title"
+
+            val user = UserEntity(
+                id = userId,
+                email = "test@example.com",
+                createdAt = Instant.now()
+            )
+
+            val todo = TodoEntity(
+                id = todoId,
+                title = sameTitle,
+                completed = false,
+                createdAt = Instant.now(),
+                user = user
+            )
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns todo
+
+            val result = todoService.updateTodoTitle(
+                userId = userId,
+                todoId = todoId,
+                request = UpdateTodoTitleRequest(title = sameTitle)
+            )
+
+            todo.title shouldBe sameTitle
+            result.title shouldBe sameTitle
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
+        }
+
+        it("throws TodoNotFoundForUserException when todo does not exist for the user") {
+            val userId = 1L
+            val todoId = 999L
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns null
+
+            shouldThrow<TodoNotFoundForUserException> {
+                todoService.updateTodoTitle(
+                    userId = userId,
+                    todoId = todoId,
+                    request = UpdateTodoTitleRequest(title = "doesn't matter")
+                )
+            }
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
+        }
+    }
+
+    describe("updateTodoCompletion") {
+
+        it("updates completion when todo exists for the user") {
+            val userId = 1L
+            val todoId = 10L
+
+            val user = UserEntity(
+                id = userId,
+                email = "test@example.com",
+                createdAt = Instant.now()
+            )
+
+            val todo = TodoEntity(
+                id = todoId,
+                title = "Apply for jobs",
+                completed = false,
+                createdAt = Instant.now(),
+                user = user
+            )
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns todo
+
+            val result = todoService.updateTodoCompletion(
+                userId = userId,
+                todoId = todoId,
+                request = UpdateTodoCompletionRequest(completed = true)
+            )
+
+            todo.completed shouldBe true
+
+            result.id shouldBe todoId
+            result.title shouldBe "Apply for jobs"
+            result.completed shouldBe true
+            result.createdAt shouldBe todo.createdAt
+            result.userId shouldBe userId
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
+        }
+
+        it("does not change completion when the value is the same") {
+            val userId = 1L
+            val todoId = 10L
+
+            val user = UserEntity(
+                id = userId,
+                email = "test@example.com",
+                createdAt = Instant.now()
+            )
+
+            val todo = TodoEntity(
+                id = todoId,
+                title = "Apply for jobs",
+                completed = true,
+                createdAt = Instant.now(),
+                user = user
+            )
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns todo
+
+            val result = todoService.updateTodoCompletion(
+                userId = userId,
+                todoId = todoId,
+                request = UpdateTodoCompletionRequest(completed = true)
+            )
+
+            todo.completed shouldBe true
+            result.completed shouldBe true
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
+        }
+
+        it("throws TodoNotFoundForUserException when todo does not exist for the user") {
+            val userId = 1L
+            val todoId = 999L
+
+            every { todoRepository.findByIdAndUser_Id(todoId, userId) } returns null
+
+            shouldThrow<TodoNotFoundForUserException> {
+                todoService.updateTodoCompletion(
+                    userId = userId,
+                    todoId = todoId,
+                    request = UpdateTodoCompletionRequest(completed = true)
+                )
+            }
+
+            verify(exactly = 1) { todoRepository.findByIdAndUser_Id(todoId, userId) }
+            verify(exactly = 0) { todoRepository.save(any()) }
+            confirmVerified(todoRepository)
         }
     }
 })


### PR DESCRIPTION
### Summary
- Introduced two endpoints for PATCH `todo.title`  and `title.completed` related tests

### Changes:
- Added nested routes for PATCH `/users/{userId}/todos/{todoId}/title` and PATCH `/users/{userId}/todos/{todoId}/completed`
- Added request DTOs for `title` and `completed`
- Updated `TodoRepository` to have find by todoId and userId to enforce user ownership since there's no auth in this app
- Added new exception to be thrown when a given todoId does not exist for a given userId
- Added related service methods to `TodoService`
- Added file for generally useful sql queries for the app (not used in the code at all)
- Updated detekt config to ignore underscores in function names as they're needed to show entity relationship traversal in repository methods
- Added missing Jackson kotlin dependency and updated `application.yml` to stop Jackson from treating missing/null booleans as "false" by default