### PR TITLE
feat(todo): get todo and get all todos endpoints

### DIFF
--- a/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/controller/TodoController.kt
@@ -8,6 +8,7 @@ import com.github.cdraz.todoapi.service.TodoService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,6 +29,21 @@ class TodoController(
         @Valid @RequestBody request: CreateTodoRequest
     ): TodoResponse =
         todoService.createTodo(userId, request)
+
+    @GetMapping
+    @ResponseStatus(OK)
+    fun getAllTodos(
+        @PathVariable userId: Long
+    ) : List<TodoResponse> =
+        todoService.getTodosForUser(userId)
+
+    @GetMapping("/{todoId}")
+    @ResponseStatus(OK)
+    fun getTodo(
+        @PathVariable userId: Long,
+        @PathVariable todoId: Long
+    ) : TodoResponse =
+          todoService.getTodo(userId, todoId)
 
     @PatchMapping("/{todoId}/title")
     @ResponseStatus(OK)

--- a/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/exception/GlobalExceptionHandler.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -114,6 +115,22 @@ class GlobalExceptionHandler {
                 status = HttpStatus.NOT_FOUND.value(),
                 error = "Todo not found",
                 message = ex.message
+            )
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatch(ex: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+        val name = ex.name
+        val value = ex.value?.toString()
+        val expected = ex.requiredType?.simpleName ?: "required type"
+
+        return ResponseEntity.badRequest().body(
+            ErrorResponse(
+                status = HttpStatus.BAD_REQUEST.value(),
+                error = "Invalid parameter",
+                message = "Parameter '$name' must be a valid $expected",
+                details = mapOf(name to "Got '$value'")
             )
         )
     }

--- a/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoRepository.kt
@@ -2,8 +2,29 @@ package com.github.cdraz.todoapi.repository
 
 import com.github.cdraz.todoapi.entity.TodoEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TodoRepository : JpaRepository<TodoEntity, Long> {
     // underscore to demonstrate relationship traversal; we want todo.user.id not todo.userId
     fun findByIdAndUser_Id(id: Long, userId: Long): TodoEntity?
+
+    fun findAllProjectedByUser_IdOrderByCreatedAtDesc(userId: Long): List<TodoView>
+
+    @Query(
+        """
+        select 
+            t.id as id,
+            t.title as title,
+            t.completed as completed,
+            t.createdAt as createdAt,
+            t.user.id as userId
+        from TodoEntity t
+        where t.id = :id and t.user.id = :userId
+        """
+    )
+    fun findViewByIdAndUserId(
+        @Param("id") id: Long,
+        @Param("userId") userId: Long
+    ): TodoView?
 }

--- a/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoView.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/repository/TodoView.kt
@@ -1,0 +1,11 @@
+package com.github.cdraz.todoapi.repository
+
+import java.time.Instant
+
+interface TodoView {
+    val id: Long
+    val title: String
+    val completed: Boolean
+    val createdAt: Instant
+    val userId: Long
+}

--- a/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
+++ b/src/main/kotlin/com/github/cdraz/todoapi/service/TodoService.kt
@@ -8,6 +8,7 @@ import com.github.cdraz.todoapi.entity.TodoEntity
 import com.github.cdraz.todoapi.exception.TodoNotFoundForUserException
 import com.github.cdraz.todoapi.exception.UserNotFoundException
 import com.github.cdraz.todoapi.repository.TodoRepository
+import com.github.cdraz.todoapi.repository.TodoView
 import com.github.cdraz.todoapi.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -17,6 +18,24 @@ class TodoService(
     private val todoRepository: TodoRepository,
     private val userRepository: UserRepository
 ) {
+
+    fun getTodo(userId: Long, todoId: Long): TodoResponse {
+        val todoView = todoRepository.findViewByIdAndUserId(todoId, userId)
+        if (todoView != null) return todoView.toResponse()
+        // if nothing found, check if user exists
+        if (!userRepository.existsById(userId)) {
+            throw UserNotFoundException(userId)
+        }
+        throw TodoNotFoundForUserException(todoId, userId)
+    }
+
+    fun getTodosForUser(userId: Long): List<TodoResponse> {
+        if (!userRepository.existsById(userId)) {
+            throw UserNotFoundException(userId)
+        }
+        return todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(userId)
+            .map { it.toResponse() }
+    }
 
     @Transactional
     fun createTodo(userId: Long, request: CreateTodoRequest): TodoResponse {
@@ -66,4 +85,14 @@ class TodoService(
             createdAt = this.createdAt,
             userId = this.user.id
         )
+
+    private fun TodoView.toResponse(): TodoResponse =
+        TodoResponse(
+            id = id,
+            title = title,
+            completed = completed,
+            createdAt = createdAt,
+            userId = userId
+        )
+
 }

--- a/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/controller/TodoControllerWebMvcTest.kt
@@ -5,6 +5,9 @@ import com.github.cdraz.todoapi.dto.TodoResponse
 import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
 import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.service.TodoService
+import com.github.cdraz.todoapi.exception.TodoNotFoundForUserException
+import com.github.cdraz.todoapi.exception.UserNotFoundException
+import org.springframework.test.web.servlet.get
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
@@ -25,6 +28,131 @@ class TodoControllerWebMvcTest {
 
     @MockkBean
     lateinit var todoService: TodoService
+
+    @Test
+    fun `GET users userId todos returns 200 and list of todos`() {
+        val userId = 1L
+        val t1 = TodoResponse(
+            id = 2L,
+            title = "Newest",
+            completed = false,
+            createdAt = Instant.parse("2026-02-01T10:00:00Z"),
+            userId = userId
+        )
+        val t2 = TodoResponse(
+            id = 1L,
+            title = "Older",
+            completed = true,
+            createdAt = Instant.parse("2026-02-01T09:00:00Z"),
+            userId = userId
+        )
+
+        every { todoService.getTodosForUser(userId) } returns listOf(t1, t2)
+
+        mockMvc.get("/users/$userId/todos")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.length()") { value(2) }
+                jsonPath("$[0].id") { value(2) }
+                jsonPath("$[0].title") { value("Newest") }
+                jsonPath("$[0].completed") { value(false) }
+                jsonPath("$[0].userId") { value(1) }
+                jsonPath("$[1].id") { value(1) }
+                jsonPath("$[1].completed") { value(true) }
+            }
+
+        verify(exactly = 1) { todoService.getTodosForUser(userId) }
+    }
+
+    @Test
+    fun `GET users userId todos returns 200 and empty list when no todos`() {
+        val userId = 1L
+
+        every { todoService.getTodosForUser(userId) } returns emptyList()
+
+        mockMvc.get("/users/$userId/todos")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.length()") { value(0) }
+            }
+
+        verify(exactly = 1) { todoService.getTodosForUser(userId) }
+    }
+
+    @Test
+    fun `GET users userId todos todoId returns 200 and todo`() {
+        val userId = 1L
+        val todoId = 2L
+
+        val response = TodoResponse(
+            id = todoId,
+            title = "Apply for jobs",
+            completed = false,
+            createdAt = Instant.parse("2026-02-01T10:00:00Z"),
+            userId = userId
+        )
+
+        every { todoService.getTodo(userId, todoId) } returns response
+
+        mockMvc.get("/users/$userId/todos/$todoId")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.id") { value(2) }
+                jsonPath("$.title") { value("Apply for jobs") }
+                jsonPath("$.completed") { value(false) }
+                jsonPath("$.userId") { value(1) }
+            }
+
+        verify(exactly = 1) { todoService.getTodo(userId, todoId) }
+    }
+
+    @Test
+    fun `GET users userId todos returns 400 when userId is not a number`() {
+        mockMvc.get("/users/abc/todos")
+            .andExpect {
+                status { isBadRequest() }
+            }
+
+        verify(exactly = 0) { todoService.getTodosForUser(any()) }
+    }
+
+    @Test
+    fun `GET users userId todos todoId returns 400 when todoId is not a number`() {
+        mockMvc.get("/users/1/todos/abc")
+            .andExpect {
+                status { isBadRequest() }
+            }
+
+        verify(exactly = 0) { todoService.getTodo(any(), any()) }
+    }
+
+    @Test
+    fun `GET users userId todos returns 404 when user does not exist`() {
+        val userId = 999L
+        every { todoService.getTodosForUser(userId) } throws UserNotFoundException(userId)
+
+        mockMvc.get("/users/$userId/todos")
+            .andExpect {
+                status { isNotFound() }
+            }
+
+        verify(exactly = 1) { todoService.getTodosForUser(userId) }
+    }
+
+    @Test
+    fun `GET users userId todos todoId returns 404 when todo not found for user`() {
+        val userId = 1L
+        val todoId = 999L
+
+        every { todoService.getTodo(userId, todoId) } throws TodoNotFoundForUserException(todoId, userId)
+
+        mockMvc.get("/users/$userId/todos/$todoId")
+            .andExpect {
+                status { isNotFound() }
+            }
+
+        verify(exactly = 1) { todoService.getTodo(userId, todoId) }
+    }
 
     @Test
     fun `POST users userId todos returns 201 when request is valid`() {

--- a/src/test/kotlin/com/github/cdraz/todoapi/service/TodoServiceTest.kt
+++ b/src/test/kotlin/com/github/cdraz/todoapi/service/TodoServiceTest.kt
@@ -1,6 +1,7 @@
 package com.github.cdraz.todoapi.service
 
 import com.github.cdraz.todoapi.dto.CreateTodoRequest
+import com.github.cdraz.todoapi.dto.TodoResponse
 import com.github.cdraz.todoapi.dto.UpdateTodoCompletionRequest
 import com.github.cdraz.todoapi.dto.UpdateTodoTitleRequest
 import com.github.cdraz.todoapi.entity.TodoEntity
@@ -8,6 +9,7 @@ import com.github.cdraz.todoapi.entity.UserEntity
 import com.github.cdraz.todoapi.exception.TodoNotFoundForUserException
 import com.github.cdraz.todoapi.exception.UserNotFoundException
 import com.github.cdraz.todoapi.repository.TodoRepository
+import com.github.cdraz.todoapi.repository.TodoView
 import com.github.cdraz.todoapi.repository.UserRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
@@ -28,6 +30,148 @@ class TodoServiceTest : DescribeSpec({
 
     afterTest {
         clearMocks(todoRepository, userRepository)
+    }
+
+    describe("getTodo") {
+
+        it("returns TodoResponse when todo exists for the user (does not check user existence)") {
+            val userId = 1L
+            val todoId = 10L
+            val createdAt = Instant.parse("2026-02-01T10:00:00Z")
+
+            val todoView = mockk<TodoView>(relaxed = false)
+            every { todoView.id } returns todoId
+            every { todoView.title } returns "Apply for jobs"
+            every { todoView.completed } returns false
+            every { todoView.createdAt } returns createdAt
+            every { todoView.userId } returns userId
+
+            every { todoRepository.findViewByIdAndUserId(todoId, userId) } returns todoView
+
+            val result = todoService.getTodo(userId, todoId)
+
+            result shouldBe TodoResponse(
+                id = todoId,
+                title = "Apply for jobs",
+                completed = false,
+                createdAt = createdAt,
+                userId = userId
+            )
+
+            verify(exactly = 1) { todoRepository.findViewByIdAndUserId(todoId, userId) }
+            verify(exactly = 0) { userRepository.existsById(any()) }
+            confirmVerified(todoRepository, userRepository)
+        }
+
+        it("throws UserNotFoundException when todo is not found and user does not exist") {
+            val userId = 999L
+            val todoId = 10L
+
+            every { todoRepository.findViewByIdAndUserId(todoId, userId) } returns null
+            every { userRepository.existsById(userId) } returns false
+
+            shouldThrow<UserNotFoundException> {
+                todoService.getTodo(userId, todoId)
+            }
+
+            verify(exactly = 1) { todoRepository.findViewByIdAndUserId(todoId, userId) }
+            verify(exactly = 1) { userRepository.existsById(userId) }
+            confirmVerified(todoRepository, userRepository)
+        }
+
+        it("throws TodoNotFoundForUserException when todo is not found but user exists") {
+            val userId = 1L
+            val todoId = 999L
+
+            every { todoRepository.findViewByIdAndUserId(todoId, userId) } returns null
+            every { userRepository.existsById(userId) } returns true
+
+            shouldThrow<TodoNotFoundForUserException> {
+                todoService.getTodo(userId, todoId)
+            }
+
+            verify(exactly = 1) { todoRepository.findViewByIdAndUserId(todoId, userId) }
+            verify(exactly = 1) { userRepository.existsById(userId) }
+            confirmVerified(todoRepository, userRepository)
+        }
+    }
+
+    describe("getTodosForUser") {
+
+        it("returns todos for existing user ordered by createdAt desc") {
+            val userId = 1L
+            val createdAt1 = Instant.parse("2026-02-01T10:00:00Z")
+            val createdAt2 = Instant.parse("2026-02-01T09:00:00Z")
+
+            val v1 = mockk<TodoView>(relaxed = false)
+            every { v1.id } returns 2L
+            every { v1.title } returns "Newest"
+            every { v1.completed } returns false
+            every { v1.createdAt } returns createdAt1
+            every { v1.userId } returns userId
+
+            val v2 = mockk<TodoView>(relaxed = false)
+            every { v2.id } returns 1L
+            every { v2.title } returns "Older"
+            every { v2.completed } returns true
+            every { v2.createdAt } returns createdAt2
+            every { v2.userId } returns userId
+
+            every { userRepository.existsById(userId) } returns true
+            every { todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(userId) } returns listOf(v1, v2)
+
+            val result = todoService.getTodosForUser(userId)
+
+            result shouldBe listOf(
+                TodoResponse(
+                    id = 2L,
+                    title = "Newest",
+                    completed = false,
+                    createdAt = createdAt1,
+                    userId = userId
+                ),
+                TodoResponse(
+                    id = 1L,
+                    title = "Older",
+                    completed = true,
+                    createdAt = createdAt2,
+                    userId = userId
+                )
+            )
+
+            verify(exactly = 1) { userRepository.existsById(userId) }
+            verify(exactly = 1) { todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(userId) }
+            confirmVerified(todoRepository, userRepository)
+        }
+
+        it("returns an empty list when user exists but has no todos") {
+            val userId = 1L
+
+            every { userRepository.existsById(userId) } returns true
+            every { todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(userId) } returns emptyList()
+
+            val result = todoService.getTodosForUser(userId)
+
+            result shouldBe emptyList()
+
+            verify(exactly = 1) { userRepository.existsById(userId) }
+            verify(exactly = 1) { todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(userId) }
+            confirmVerified(todoRepository, userRepository)
+        }
+
+        it("throws UserNotFoundException when user does not exist (does not query todos)") {
+            val userId = 999L
+
+            every { userRepository.existsById(userId) } returns false
+
+            shouldThrow<UserNotFoundException> {
+                todoService.getTodosForUser(userId)
+            }
+
+            verify(exactly = 1) { userRepository.existsById(userId) }
+            verify(exactly = 0) { todoRepository.findAllProjectedByUser_IdOrderByCreatedAtDesc(any()) }
+            confirmVerified(todoRepository, userRepository)
+        }
     }
 
     describe("createTodo") {


### PR DESCRIPTION
### Summary
This PR adds read support for todos scoped to a user and improves API robustness and test coverage.

### Changes
- Added GET endpoints for:
  - Fetching all todos for a user
  - Fetching a single todo by user ID and todo ID
- Introduced read projections (`TodoView`), DTOs, and repository methods to support reads
- Added related service-layer methods with clear errors (`UserNotFoundException`, `TodoNotFoundForUserException`)
- Improved global exception handling to better handle path variable type mismatches
- Added unit tests for new service methods and controller GET endpoints